### PR TITLE
Fix React warning

### DIFF
--- a/build/form/InputField.js
+++ b/build/form/InputField.js
@@ -146,7 +146,8 @@
     }, {
       key: 'value',
       get: function get() {
-        return this.context.formValueScope.getValue(this.props.name);
+        // fall back to empty string to keep it a controlled component
+        return this.context.formValueScope.getValue(this.props.name) || '';
       },
       set: function set(newValue) {
         this.context.formValueScope.setValue(this.props.name, newValue);

--- a/src/form/InputField.jsx
+++ b/src/form/InputField.jsx
@@ -17,7 +17,8 @@ export default class InputField extends React.Component {
   }
 
   get value () {
-    return this.context.formValueScope.getValue(this.props.name)
+    // fall back to empty string to keep it a controlled component
+    return this.context.formValueScope.getValue(this.props.name) || ''
   }
 
   set value (newValue) {


### PR DESCRIPTION
Without this fix, it is easy to run into "Input is changing from an uncontrolled to a controlled component blah blah". For example, that warning appeared in one of our Karma tests.

@erikmueller please review
