### PR TITLE
Fix invalid color strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@epages/react-components",
   "description": "A zoo of useful React components.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "scripts": {
     "start": "node ./webpack.devserver.js",
     "test": "jest",

--- a/src/form/ColorpickerField.jsx
+++ b/src/form/ColorpickerField.jsx
@@ -4,6 +4,22 @@ import React, {Component, PureComponent} from 'react'
 
 import formField from './formField'
 
+/**
+ * check if a string is a valid color value
+ *
+ * @param {string} value color value string
+ * @returns {boolean} whether the string is a valid color or not
+ */
+function isValidColor (value) {
+  try {
+    // `color` throws an error when the value is not a valid color
+    color(value)
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
 class Coordinator extends PureComponent {
   static propTypes = {
     coords: PropTypes.array.isRequired,
@@ -110,14 +126,16 @@ export class ColorpickerFieldRaw extends Component {
   }
 
   changeColor = (color) => {
-    this.setState({intermediateHexInput: color.hex()})
+    if (isValidColor(color.string())) {
+      this.setState({intermediateHexInput: color.hex()})
 
-    const preciseColor = color
-      .hue(Math.round(color.hue()))
-      .hsl()
-      .string()
+      const preciseColor = color
+        .hue(Math.round(color.hue()))
+        .hsl()
+        .string()
 
-    this.props.onChange(preciseColor)
+      this.props.onChange(preciseColor)
+    }
   }
 
   handleSvChange = ([x, y]) => {
@@ -207,9 +225,9 @@ export class ColorpickerFieldRaw extends Component {
 
             this.setState({intermediateHexInput: value})
 
-            try {
+            if (isValidColor(value)) {
               this.props.onChange(color(value).hsl().round().string())
-            } catch (e) {}
+            }
           }} />
       </div>
     )

--- a/test/form/ColorpickerField.spec.jsx
+++ b/test/form/ColorpickerField.spec.jsx
@@ -85,7 +85,7 @@ describe('Colorpicker', function () {
     ])
   })
 
-  it('does ignores invalid colors from ', function () {
+  it('does ignore invalid colors', function () {
     const onChange = sinon.spy().named('onChange')
     const {hueSlider, svCanvas} = render({onChange})
 

--- a/test/form/ColorpickerField.spec.jsx
+++ b/test/form/ColorpickerField.spec.jsx
@@ -84,4 +84,14 @@ describe('Colorpicker', function () {
       [`hsl(146, ${s}, ${v})`]
     ])
   })
+
+  it('does ignores invalid colors from ', function () {
+    const onChange = sinon.spy().named('onChange')
+    const {hueSlider, svCanvas} = render({onChange})
+
+    TestUtils.Simulate.mouseDown(svCanvas, {clientX: '55px', clientY: 75})
+    TestUtils.Simulate.mouseDown(hueSlider, {clientX: '0px', clientY: '122px'})
+
+    expect(onChange, 'was not called')
+  })
 })


### PR DESCRIPTION
Check color values before giving them to `onChange` handler.

In some cases an invalid color string was used for onChange.