### PR TITLE
Fix: Support number and bool values in DropDownField

### DIFF
--- a/src/form/DropDownField.jsx
+++ b/src/form/DropDownField.jsx
@@ -3,31 +3,37 @@ import React from 'react'
 
 import formField from './formField'
 
+const stringOrNumberOrBool = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.number,
+  PropTypes.bool
+])
+
 export class DropDownFieldRaw extends React.Component {
   static propTypes = {
-    value: PropTypes.string.isRequired,
+    value: stringOrNumberOrBool.isRequired,
     onChange: PropTypes.func.isRequired,
     name: PropTypes.string,
     scopedName: PropTypes.string,
     options: PropTypes.arrayOf(PropTypes.shape({
-      value: PropTypes.string.isRequired,
+      value: stringOrNumberOrBool.isRequired,
       label: PropTypes.string.isRequired
     })).isRequired
   }
 
   render () {
-    const {value, onChange, name, scopedName, options, ...other} = this.props // eslint-disable-line no-unused-vars
+    const {value, onChange, name, scopedName, options, ...other} = this.props
 
     return (
       <select
         {...other}
         name={scopedName}
-        value={options.find((opt) => opt.value === value).value}
-        onChange={(event) => onChange(event.target.value)}>
+        value={String(value)}
+        onChange={event => onChange(options.find(({value}) => String(value) === event.target.value).value)}>
         {options.map((option, index) =>
           <option
             key={index}
-            value={option.value}>
+            value={String(option.value)}>
             {option.label}
           </option>
         )}

--- a/test/form/DropDownField.spec.jsx
+++ b/test/form/DropDownField.spec.jsx
@@ -5,24 +5,28 @@ import expect from 'unexpected'
 
 import {DropDownFieldRaw} from '../../src/form/DropDownField'
 
-function render ({value = 'm'} = {}) {
-  const sizes = [
-    {value: 's', label: 'Small'},
-    {value: 'm', label: 'Medium'},
-    {value: 'l', label: 'Large'}
-  ]
+function render (props) {
   const onChange = sinon.spy()
   const dom = TestUtils.renderIntoDocument(
-    <DropDownFieldRaw value={value} onChange={onChange} options={sizes} />
+    <DropDownFieldRaw
+      value="m"
+      onChange={onChange}
+      options={[
+        {value: 's', label: 'Small'},
+        {value: 'm', label: 'Medium'},
+        {value: 'l', label: 'Large'}
+      ]}
+      {...props}
+    />
   )
-  const sizeField = TestUtils.findOne(dom, 'select')
+  const testField = TestUtils.findOne(dom, 'select')
 
-  return {onChange, dom, sizeField}
+  return {onChange, dom, testField}
 }
 
 describe('DropDownField', function () {
-  it('renders', function () {
-    const {dom} = render()
+  it('should work with string options', function () {
+    const {dom, onChange, testField} = render()
 
     expect(dom, 'to have rendered',
       <select value="m">
@@ -31,13 +35,53 @@ describe('DropDownField', function () {
         <option value="l">Large</option>
       </select>
     )
-  })
-
-  it('returns new value', function () {
-    const {onChange, sizeField} = render()
 
     expect(onChange, 'was not called')
-    TestUtils.Simulate.change(sizeField, {target: {value: 'l'}})
+    TestUtils.Simulate.change(testField, {target: {value: 'l'}})
     expect(onChange, 'to have calls satisfying', () => onChange('l'))
+  })
+
+  it('should work with number options', function () {
+    const {dom, onChange, testField} = render({
+      value: 200,
+      options: [
+        {value: 200, label: '200'},
+        {value: 200.5, label: '200.5'},
+        {value: 300, label: '300'}
+      ]
+    })
+
+    expect(dom, 'to have rendered',
+      <select value="200">
+        <option value="200">200</option>
+        <option value="200.5">200.5</option>
+        <option value="300">300</option>
+      </select>
+    )
+
+    expect(onChange, 'was not called')
+    TestUtils.Simulate.change(testField, {target: {value: '200.5'}})
+    expect(onChange, 'to have calls satisfying', () => onChange(200.5))
+  })
+
+  it('should work with boolean options', function () {
+    const {dom, onChange, testField} = render({
+      value: false,
+      options: [
+        {value: true, label: 'Opened'},
+        {value: false, label: 'Closed'}
+      ]
+    })
+
+    expect(dom, 'to have rendered',
+      <select value="false">
+        <option value="true">Opened</option>
+        <option value="false">Closed</option>
+      </select>
+    )
+
+    expect(onChange, 'was not called')
+    TestUtils.Simulate.change(testField, {target: {value: 'true'}})
+    expect(onChange, 'to have calls satisfying', () => onChange(true))
   })
 })


### PR DESCRIPTION
This re-adds the possibility to use `number` and `boolean` primitive
values with "value" and "options" props of the `DropDownField`
component.

In order to still have the possibility to opt in to autocompletion via
the HTML "autocomplete" attribute on the field, this doesn't use the
[index-based approach] as it was with `react-components` < v0.2.3.

[index-based approach]: https://github.com/ePages-de/react-components/blob/9be9545d093716e83de9f4811ce043f90ecf50f3/src/form/DropDownField.jsx#L22-L34