### PR TITLE
Update: Only validate asynchronously if needed

### DIFF
--- a/test/form/ErrorMessage.spec.jsx
+++ b/test/form/ErrorMessage.spec.jsx
@@ -1,4 +1,3 @@
-import Bluebird from 'bluebird'
 import Immutable from 'immutable'
 import React from 'react'
 import TestUtils from 'react-testutils-additions'
@@ -25,12 +24,11 @@ function render ({validate} = {}) {
 }
 
 describe('ErrorMessage', function () {
-  it('renders', async function () {
+  it('renders', function () {
     const validate = (value) => !value.get('name') ? Immutable.fromJS({name: 'required'}) : null
     const {dom, form, nameField} = render({validate})
 
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(dom, 'to have rendered',
       <form>
@@ -41,7 +39,6 @@ describe('ErrorMessage', function () {
 
     TestUtils.Simulate.change(nameField, {target: {value: 'foobar'}})
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(dom, 'to have rendered',
       <form>

--- a/test/form/Form.spec.jsx
+++ b/test/form/Form.spec.jsx
@@ -60,24 +60,22 @@ describe('Form', function () {
     )
   })
 
-  it('returns original instance if unchanged', async function () {
+  it('returns original instance if unchanged', function () {
     const {onSubmit, form} = render()
 
     expect(onSubmit, 'was not called')
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(onSubmit, 'was called once')
   })
 
-  it('returns new value', async function () {
+  it('returns new value', function () {
     const {onSubmit, form, firstNameField, lastNameField, streetField} = render()
 
     TestUtils.Simulate.change(firstNameField, {target: {value: 'foo'}})
     TestUtils.Simulate.change(lastNameField, {target: {value: 'bar'}})
     TestUtils.Simulate.change(streetField, {target: {value: 'apple'}})
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(onSubmit, 'was called once')
     expect(onSubmit, 'to have calls satisfying', function () {
@@ -91,31 +89,27 @@ describe('Form', function () {
     })
   })
 
-  it('does not submit if disabled', async function () {
+  it('does not submit if disabled', function () {
     const {onSubmit, form} = render({disabled: true})
 
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(onSubmit, 'was not called')
   })
 
-  it('respects validation', async function () {
+  it('respects validation', function () {
     const validate = (value) => Immutable.fromJS({firstName: !value.get('firstName') ? 'required' : null})
     const {onSubmit, form, firstNameField, lastNameField} = render({validate})
 
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(onSubmit, 'was not called')
     TestUtils.Simulate.change(lastNameField, {target: {value: 'bar'}})
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(onSubmit, 'was not called')
     TestUtils.Simulate.change(firstNameField, {target: {value: 'foo'}})
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(onSubmit, 'was called once')
   })
@@ -138,12 +132,11 @@ describe('Form', function () {
   })
 
   // https://github.com/ePages-de/react-components/issues/8
-  it('calls validate while typing', async function () {
+  it('calls validate while typing', function () {
     const validate = sinon.spy()
     const {onSubmit, firstNameField} = render({validate})
 
     TestUtils.Simulate.change(firstNameField)
-    await Bluebird.delay(1)
 
     expect(validate, 'was called')
     expect(onSubmit, 'was not called')
@@ -195,7 +188,7 @@ describe('Form', function () {
     expect(dom, 'not to contain', <div>first name required</div>)
   })
 
-  it('calls validation correctly (with second argument false before first submit and true afterwards)', async function () {
+  it('calls validation correctly (with second argument false before first submit and true afterwards)', function () {
     const validate = sinon.spy(() => Immutable.fromJS({firstName: 'required'}))
     const {onSubmit, form, firstNameField} = render({validate})
 
@@ -204,7 +197,6 @@ describe('Form', function () {
     TestUtils.Simulate.submit(form)
     TestUtils.Simulate.change(firstNameField, {target: {value: '123'}})
     TestUtils.Simulate.change(firstNameField, {target: {value: '1234'}})
-    await Bluebird.delay(1)
 
     expect(onSubmit, 'to have calls satisfying', () => {
       validate(Immutable.fromJS({firstName: '1', lastName: '', address: {street: ''}}), false)
@@ -257,12 +249,11 @@ describe('Form', function () {
     expect(formComponent, 'to have rendered', <div>pristine true</div>)
   })
 
-  it('detects submitting state', async function () {
+  it('detects submitting state', function () {
     const {dom: formComponent, form, onSubmit} = render()
 
     expect(formComponent, 'to have rendered', <div>submitting false</div>)
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(formComponent, 'to have rendered', <div>submitting false</div>)
 
@@ -270,7 +261,6 @@ describe('Form', function () {
     onSubmit.returns(submit)
     expect(formComponent, 'to have rendered', <div>submitting false</div>)
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(formComponent, 'to have rendered', <div>submitting true</div>)
     return submit.then(() => {

--- a/test/form/FormValueScope.spec.jsx
+++ b/test/form/FormValueScope.spec.jsx
@@ -1,4 +1,3 @@
-import Bluebird from 'bluebird'
 import Immutable from 'immutable'
 import React from 'react'
 import TestUtils from 'react-testutils-additions'
@@ -50,7 +49,7 @@ describe('FormValueScope', function () {
     )
   })
 
-  it('passes through validation', async function () {
+  it('passes through validation', function () {
     const validate = (value) => Immutable.fromJS({
       sub: {
         name: !value.getIn(['sub', 'name']) ? 'required' : null
@@ -59,7 +58,6 @@ describe('FormValueScope', function () {
     const {dom, form, nameField} = render({validate})
 
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(dom, 'to have rendered',
       <form>
@@ -73,7 +71,6 @@ describe('FormValueScope', function () {
 
     TestUtils.Simulate.change(nameField, {target: {value: ''}})
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(dom, 'to have rendered',
       <form>

--- a/test/form/IteratorField.spec.jsx
+++ b/test/form/IteratorField.spec.jsx
@@ -1,4 +1,3 @@
-import Bluebird from 'bluebird'
 import Immutable from 'immutable'
 import React from 'react'
 import TestUtils from 'react-testutils-additions'
@@ -81,7 +80,7 @@ describe('IteratorField', function () {
     )
   })
 
-  it('returns new value', async function () {
+  it('returns new value', function () {
     const {onSubmit, form, tagNameFields} = render()
 
     expect(tagNameFields, 'to have length', 2)
@@ -89,7 +88,6 @@ describe('IteratorField', function () {
     TestUtils.Simulate.change(tagNameFields[0], {target: {value: 'first-new'}})
     TestUtils.Simulate.change(tagNameFields[1], {target: {value: 'second-new'}})
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(onSubmit, 'was called once')
     expect(onSubmit, 'to have calls satisfying', function () {
@@ -102,7 +100,7 @@ describe('IteratorField', function () {
     })
   })
 
-  it('passes through validation', async function () {
+  it('passes through validation', function () {
     const validate = (value) => new Immutable.Map({
       tags: value.get('tags').map((tag) => new Immutable.Map({
         name: !tag.get('name') ? 'required' : null
@@ -126,7 +124,6 @@ describe('IteratorField', function () {
     )
     TestUtils.Simulate.change(tagNameFields[1], {target: {value: ''}})
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(dom, 'to have rendered',
       <form>

--- a/test/form/SelectableInputField.spec.jsx
+++ b/test/form/SelectableInputField.spec.jsx
@@ -1,4 +1,3 @@
-import Bluebird from 'bluebird'
 import Immutable from 'immutable'
 import React from 'react'
 import TestUtils from 'react-testutils-additions'
@@ -51,7 +50,7 @@ describe('SelectableInputField', function () {
     )
   })
 
-  it('returns new value', async function () {
+  it('returns new value', function () {
     const {form, onSubmit, inputField0, inputField1} = render()
 
     expect(onSubmit, 'was not called')
@@ -66,7 +65,6 @@ describe('SelectableInputField', function () {
     expect(inputField1.value, 'to be', 'ab')
 
     TestUtils.Simulate.submit(form)
-    await Bluebird.delay(1)
 
     expect(onSubmit, 'was called once')
     expect(onSubmit, 'to have calls satisfying', function () {


### PR DESCRIPTION
This changes form validation to only handle it asynchronously if the
return value of `props.validate` is a thenable (i.e. has a "then"
method). Otherwise, validation will be synchronous (like it was before
support for asynchronous validation was added with version 0.3.0).