### PR TITLE
Build: Decrease bundle size

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,8 +4,6 @@
     [
       "@babel/preset-env",
       {
-        "useBuiltIns": "usage",
-        "corejs": 3,
         "exclude": ["@babel/plugin-transform-regenerator"]
       }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2885,11 +2885,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-      "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ=="
-    },
     "core-js-compat": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "cacheDirectory": "<rootDir>/.cache/jest"
   },
   "dependencies": {
-    "core-js": "3.1.4",
     "immutablediff": "0.4.4"
   }
 }


### PR DESCRIPTION
Version 0.10.0 increased the resulting minified and gzipped bundle size
from 10.2 kB (v0.9.1) to 23.2 kB, primarily due to included `core-js`
polyfills (via `@babel/preset-env` `"useBuiltIns": "usage"` option).

- Remove using the "useBuiltIns" option, so that `@babel/preset-env`
  only compiles ES2015+ to ES5 (similar to what the previously used
  `babel-preset-es2015` did in `@epages/react-components` v0.9.1).
- Results in a 11.8 kB minified and gzipped build size.

To quote the [`@babel/preset-env` v1.x README][1]:
> Without any configuration options, babel-preset-env behaves exactly
> the same as babel-preset-latest (or babel-preset-es2015,
> babel-preset-es2016, and babel-preset-es2017 together).

See also: [babel-preset-es2015 -> babel-preset-env][2]

[1]: https://github.com/babel/babel-preset-env/blob/1.x/README.md#babel-preset-env----
[2]: https://babeljs.io/docs/en/env/